### PR TITLE
Update guide language for clarity

### DIFF
--- a/connector guide.md
+++ b/connector guide.md
@@ -3,40 +3,42 @@ As of 2/12/2021, our connector is fully functional with both visualizing geograp
 
 Before reading further, please take a moment to consider your privacy concerns and read the blurb below about user data.  
 
-## Editing the connector
-*Note: these steps may be out of date. If you encounter any issues, the specification provided from Google can be found [here](https://developers.google.com/datastudio/connector/build). At the time of writing this file, the [apps script ide](https://workspaceupdates.googleblog.com/2020/12/google-apps-script-ide-better-code-editing.html) had just been updated, and our guide is designed for what is now called the "legacy" editor.*  
-1. Fork this repository (or edit it in any other way you like)
+## Preparing the connector for use
+We are working to get this connector into Google's public [Connector Gallery](https://datastudio.google.com/data). Until it is approved, you will need to run the connector from your own Google account following the steps below.
+
+*Note: Google changes changes its tools often and you may find that these instructions are out of date. At the time of writing, the [apps script ide](https://workspaceupdates.googleblog.com/2020/12/google-apps-script-ide-better-code-editing.html) had just been updated without including all features needed for GDS connectors, and our guide is designed for what is now called the "legacy" editor. If you need to modify the connector, the specification provided from Google can be found [here](https://developers.google.com/datastudio/connector/build). *  
+1. Fork this repository (or get its code in any other way you like)
 2. Head to https://www.google.com/script/start/  
 3. Click "start scripting" along the top bar
 4. Create a new project (along top bar)
-5. Copy `main.js` into `code.gs` (along with your changes)
+5. Copy `main.js` into `code.gs` (along with any changes you have made in your fork)
 6. Go to view &rarr; show manifest file &rarr; copy `appscript.json` from our repository.
-7. Create a [deployment](https://developers.google.com/datastudio/connector/deploy#create_separate_deployments) - Note that you will need to swap to the legacy editor for this.
+7. Create a [deployment](https://developers.google.com/datastudio/connector/deploy#create_separate_deployments) - Note that you will need to switch to the legacy editor for this.
 8. Using (see below)
 
 ## Using the connector
 
 1. Have a form which you've uploaded to your instance of ODK Central, as well as some data you'd like to view in Google Data Studio.
-2. Create an account which has view-only privileges. This step is not strictly necessary, but Google will [use](https://support.google.com/datastudio/answer/9053467?hl=en) your login information, which users may have varying levels of comfort with.
-3. Deploy your connector (or  use the most recent version of ours [here](https://datastudio.google.com/u/0/datasources/create?connectorId=AKfycbwlLqb1ZWaB0mPpdfG8o-JhKv6BnPubbqL-VLg9cfA)) via publish &rarr; deploy from manifest &rarr; Latest Version (head) &rarr; click on the datastudio.google.com link
-4. Using the account you'd like google to be "aware" of, login to the connector. In the Path text box, please copy the URL link to your form, as described [here](https://docs.getodk.org/central-submissions/#connecting-to-submission-data-over-odata) (e.g. https://sandbox.getodk.cloud/v1/projects/4/forms/two-repeats.svc)
-5. Once you've logged in, there will be a second configuration screen. You will need to copy the URL you entered in the first screen again to the text box in the second screen. Later you can come back to change the URL to another form you want to analyze over.
+2. Create a Central account which has view-only privileges. This step is not strictly necessary, but Google will [use](https://support.google.com/datastudio/answer/9053467?hl=en) your login information, which users may have varying levels of comfort with.
+3. Deploy your connector via publish &rarr; deploy from manifest &rarr; Latest Version (head) &rarr; click on the datastudio.google.com link
+4. Using the Central account you'd like google to be "aware" of, login to the connector. In the Path text box, please paste the OData URL for your form, as described [here](https://docs.getodk.org/central-submissions/#connecting-to-submission-data-over-odata) (e.g. https://sandbox.getodk.cloud/v1/projects/4/forms/two-repeats.svc)
+5. Once you've logged in, there will be a second configuration screen. You will need to copy the URL you entered in the first screen again to the text box in the second screen. Later you can come back to change the URL to another form you want to analyze.
 6. Click on NEXT.
 7. Now another field should appear that says "Table". (see an example image below)
 8. Click on the triangle in the "Table" field and a dropdown menu would appear. Select the repeat/Submissions table you want to access.
 9. Click on NEXT.
-10. Now you will see the number of rows in this table, and you need to input the starting row and number of rows you want to access. (This connector is only built for visualizing small amount of data. And note that if number of rows you want to access is around 50,000, it will take a couple minutes to visualize your data.) (**Note: starting row parameter is 0-indexed. i.e. if you want to access the entire dataset, your start will be 0, and number of rows should be length of dataset.**)
+10. Now you will see the number of rows in this table, and you need to input the starting row and number of rows you want to access. If you have thousands of submissions or less, you can likely pull the full dataset without difficulty. If the number of rows you want to access is around 50,000, it will take a couple minutes to transfer your data and you may want to only pull a subset. (**Note: starting row parameter is 0-indexed. i.e. if you want to access the entire dataset, your start will be 0, and number of rows should be length of dataset.**)
 11. Click on CONNECT.
-12. Make sure the types of your data are corrected. If they are not what you expect, you can manually change them.
+12. Make sure the types of your data are correct. If they are not what you expect, you can manually change them.
 13. Create a report and play with your data! Our tutorial ends here as we aren't GDS experts. Happy coding and let us know if you have any feedback!
 
 ![second configuration screen example](configuration.png)
 
 ## Google Data Studio
-We ask that before you use our connector, you take a moment to think about any privacy concerns associated with your data. [GDS](https://developers.google.com/datastudio) is a data visualization tool which is capable of working with any data sources accessible via the internet. There is an [existing ecosystem](https://datastudio.google.com/data) of community connectors, which is where we received our inspiration to create one for ODK central. It is important to note that since it will travel over the internet *your data will be "seen" (likely in encrypted form) by many networks and routers along the way*. HTTPS is, of course, very powerful and enables use of the internet for transmission extremely sensitive user information. However each use case is different, and we can't decide for you whether your security concerns are met.
+We ask that before you use our connector, you take a moment to think about any privacy concerns associated with your data. [GDS](https://developers.google.com/datastudio) is a data visualization tool which is capable of working with any data sources accessible via the internet. There is an [existing ecosystem](https://datastudio.google.com/data) of community connectors, which is where we received our inspiration to create one for ODK Central. When you connect to a data source through a connector, you have to share your credentials for that data source with Google. We recommend creating a Central [Project Viewer](https://docs.getodk.org/central-users/#web-user-roles) specifically to use with GDS.
 
 ## Example visualizaing the GEO data
-At the google data studio report/exploration page, 
+At the Google Data Studio report/exploration page, 
 1. Add your geo data field into the *Dimension* column.
 2. add another numeric field of your choosing to the *Metric* column.
 3. In the chart section of GDS, select "Bubble Map". An map with points on it should appear, like the image below.


### PR DESCRIPTION
These are mostly small edits that will hopefully be non-controversial.

I suggest removing the link to the deployment hosted by @wenjunsun because using it leads to a big scary warning. It also means @wenjunsun has to commit to keeping his deployment up to date. Until this gets in the gallery, it makes sense to me that users would have to deploy their own.

Given this suggestion, I think it makes sense to shift the purpose of the first section to preparing the connector.

Don't hesitate to push back or make counter proposals for any of this.